### PR TITLE
修复触摸失效和提供获取触摸面积

### DIFF
--- a/ManipulationDemo/MainWindow.xaml.cs
+++ b/ManipulationDemo/MainWindow.xaml.cs
@@ -248,6 +248,7 @@ namespace ManipulationDemo
             var position = stylusPointCollection[0];
             (bool success, double width, double height) = GetSize(position);
 
+#nullable enable
             string? errorMessage = null;
             if (success)
             {
@@ -262,6 +263,7 @@ namespace ManipulationDemo
             }
 
             _touchAreaProvider.Move(e.StylusDevice.Id, position.ToPoint(), new Size(width, height), errorMessage);
+#nullable restore
         }
 
         private async void OnStylusUp(object sender, StylusEventArgs e)

--- a/ManipulationDemo/MainWindow.xaml.cs
+++ b/ManipulationDemo/MainWindow.xaml.cs
@@ -229,7 +229,7 @@ namespace ManipulationDemo
             }
         }
 
-        private bool ShowTouchAreaInTouch { get; } = true;
+        private bool ShowTouchAreaInTouch { get; } = false;
 
         private void OnStylusDown(object sender, StylusDownEventArgs e)
         {

--- a/ManipulationDemo/MainWindow.xaml.cs
+++ b/ManipulationDemo/MainWindow.xaml.cs
@@ -96,7 +96,11 @@ namespace ManipulationDemo
             {
                 // 忽略
             }
+
+            _touchAreaProvider = new TouchAreaProvider(RootGrid);
         }
+
+        private readonly TouchAreaProvider _touchAreaProvider;
 
         private Storyboard StylusDownStoryboard => (Storyboard) IndicatorPanel.FindResource("Storyboard.StylusDown");
         private Storyboard StylusMoveStoryboard => (Storyboard) IndicatorPanel.FindResource("Storyboard.StylusMove");
@@ -202,7 +206,6 @@ namespace ManipulationDemo
                 // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getpointerdevices
             }
         }
-        private readonly Dictionary<int /*Id*/, PointInfo> _dictionary = [];
 
         private void OnStylusDown(object sender, StylusDownEventArgs e)
         {
@@ -212,121 +215,38 @@ namespace ManipulationDemo
             var position = stylusPointCollection[0];
             (bool success, double width, double height) = GetSize(position);
 
-            Border border = new Border
-            {
-                Background =  new SolidColorBrush(Colors.Gray)
-                {
-                    Opacity = 0.5
-                },
-                Width = Math.Max(5, width),
-                Height = Math.Max(5, height),
-                IsHitTestVisible = false,
-                HorizontalAlignment = HorizontalAlignment.Left,
-                VerticalAlignment = VerticalAlignment.Top,
-                RenderTransform = new TranslateTransform(position.X, position.Y),
-            };
-            RootGrid.Children.Add(border);
-
-            var textBlock = new TextBlock()
-            {
-                IsHitTestVisible = false,
-                HorizontalAlignment = HorizontalAlignment.Left,
-                VerticalAlignment = VerticalAlignment.Top,
-                TextWrapping = TextWrapping.Wrap,
-                RenderTransform = new TranslateTransform(position.X, position.Y),
-            };
-            RootGrid.Children.Add(textBlock);
-
-            _dictionary[e.StylusDevice.Id] = new PointInfo(position.X, position.Y, width, height, border, textBlock);
+            _touchAreaProvider.Down(e.StylusDevice.Id, position.ToPoint(), new Size(width, height));
         }
 
         private void OnStylusMove(object sender, StylusEventArgs e)
         {
             StylusMoveStoryboard.Begin();
 
-            if (_dictionary.TryGetValue(e.StylusDevice.Id, out var info))
+            var stylusPointCollection = e.GetStylusPoints(null);
+            var position = stylusPointCollection[0];
+            (bool success, double width, double height) = GetSize(position);
+
+            string? errorMessage = null;
+            if (success)
             {
-                var stylusPointCollection = e.GetStylusPoints(null);
-                var position = stylusPointCollection[0];
-                (bool success, double width, double height) = GetSize(position);
-#nullable enable
-                string? errorMessage = null;
-                if (success)
+                if (double.IsNaN(width))
                 {
-                    if (double.IsNaN(width))
-                    {
-                        errorMessage += "Origin width is NaN\r\n";
-                    }
-                    if (double.IsNaN(height))
-                    {
-                        errorMessage += "Origin height is NaN\r\n";
-                    }
+                    errorMessage += "Origin width is NaN\r\n";
                 }
-
-                var viewWidth = width;
-                var viewHeight = height;
-
-                if (width <= 0.01)
+                if (double.IsNaN(height))
                 {
-                    width = info.Width;
-                    viewWidth = width;
+                    errorMessage += "Origin height is NaN\r\n";
                 }
-
-                if (height <= 0.01)
-                {
-                    height = info.Height;
-                    viewHeight = height;
-                }
-
-                viewWidth = Math.Max(5, viewWidth);
-                viewHeight = Math.Max(5, viewHeight);
-
-                var borderRenderTransform = (TranslateTransform) info.Border.RenderTransform!;
-                borderRenderTransform.X = position.X - viewWidth / 2;
-                borderRenderTransform.Y = position.Y - viewHeight / 2;
-
-                var textBlock = info.TextBlock;
-                textBlock.Text = $"Id:{e.StylusDevice.Id}\r\nX: {position.X}, Y: {position.Y}\r\nWidth: {width:F2}, Height: {height:F2}\r\n{errorMessage}";
-
-                var textBlockRenderTransform = (TranslateTransform) textBlock.RenderTransform!;
-                textBlockRenderTransform.X = position.X;
-                textBlockRenderTransform.Y = position.Y;
-
-                _dictionary[e.StylusDevice.Id] = info with
-                {
-                    X = position.X,
-                    Y = position.Y,
-
-                    Width = width,
-                    Height = height
-                };
-#nullable restore
             }
+
+            _touchAreaProvider.Move(e.StylusDevice.Id, position.ToPoint(), new Size(width, height), errorMessage);
         }
 
         private async void OnStylusUp(object sender, StylusEventArgs e)
         {
             StylusUpStoryboard.Begin();
 
-            if (_dictionary.TryGetValue(e.StylusDevice.Id, out var info))
-            {
-                RootGrid.Children.Remove(info.Border);
-
-                info.TextBlock.Text = "IsUp=true\r\n" + info.TextBlock.Text;
-                info.TextBlock.Opacity = 0.9;
-
-                await Task.Delay(TimeSpan.FromSeconds(5));
-                info.TextBlock.Foreground = Brushes.Black;
-                info.TextBlock.Opacity = 0.5;
-                for (int i = 0; i < 5; i++)
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(1));
-                    info.TextBlock.Opacity = (5 - i) * 0.1;
-                }
-
-                await Task.Delay(TimeSpan.FromSeconds(1));
-                RootGrid.Children.Remove(info.TextBlock);
-            }
+            _touchAreaProvider.Up(e.StylusDevice.Id);
         }
 
         private (bool Success, double Width, double Height) GetSize(StylusPoint stylusPoint)
@@ -369,6 +289,7 @@ namespace ManipulationDemo
         private void OnTouchMove(object sender, TouchEventArgs e)
         {
             TouchMoveStoryboard.Begin();
+
         }
 
         private void OnTouchUp(object sender, TouchEventArgs e)
@@ -629,24 +550,5 @@ namespace ManipulationDemo
         DBT_USERDEFINED = 0xFFFF,
     }
 
-    struct PointInfo
-    {
-        public PointInfo(double x, double y, double width, double height, Border border, TextBlock textBlock)
-        {
-            X = x;
-            Y = y;
-            Width = width;
-            Height = height;
-            Border = border;
-            TextBlock = textBlock;
-        }
-
-        public double X { get; set; }
-        public double Y { get; set; }
-        public double Width { get; set; }
-        public double Height { get; set; }
-        public Border Border { get; }
-        public TextBlock TextBlock { get; }
-    }
 
 }

--- a/ManipulationDemo/Program.cs
+++ b/ManipulationDemo/Program.cs
@@ -21,8 +21,11 @@ namespace ManipulationDemo
             try
             {
                 var hwnd = FindWindow(null, "触摸以监视");
-                ShowWindow(hwnd, 9);
-//#if DEBUG
+                if(hwnd != IntPtr.Zero)
+                {
+                    ShowWindow(hwnd, 9);
+                }
+                //#if DEBUG
 //                ApplicationDestroyer.DeleteTime = TimeSpan.FromSeconds(10);
 //#endif
 //                ApplicationDestroyer.CheckAndDelete();

--- a/ManipulationDemo/TouchAreaProvider.cs
+++ b/ManipulationDemo/TouchAreaProvider.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
@@ -54,7 +55,6 @@ class TouchAreaProvider
         var (width, height) = (size.Width, size.Height);
         if (_dictionary.TryGetValue(id, out var info))
         {
-#nullable enable
             var viewWidth = width;
             var viewHeight = height;
 
@@ -93,7 +93,6 @@ class TouchAreaProvider
                 Width = width,
                 Height = height
             };
-#nullable restore
         }
     }
 

--- a/ManipulationDemo/TouchAreaProvider.cs
+++ b/ManipulationDemo/TouchAreaProvider.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media.Media3D;
+using System.Windows.Media;
+using System.Threading.Tasks;
+
+namespace ManipulationDemo;
+
+class TouchAreaProvider
+{
+    public TouchAreaProvider(Grid rootGrid)
+    {
+        RootGrid = rootGrid;
+    }
+
+    public Grid RootGrid { get; }
+    private readonly Dictionary<int /*Id*/, PointInfo> _dictionary = [];
+
+    public void Down(int id, Point position, Size size)
+    {
+        var (width, height) = (size.Width, size.Height);
+        Border border = new Border
+        {
+            Background = new SolidColorBrush(Colors.Gray)
+            {
+                Opacity = 0.5
+            },
+            Width = Math.Max(5, width),
+            Height = Math.Max(5, height),
+            IsHitTestVisible = false,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            RenderTransform = new TranslateTransform(position.X, position.Y),
+        };
+        RootGrid.Children.Add(border);
+
+        var textBlock = new TextBlock()
+        {
+            IsHitTestVisible = false,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top,
+            TextWrapping = TextWrapping.Wrap,
+            RenderTransform = new TranslateTransform(position.X, position.Y),
+        };
+        RootGrid.Children.Add(textBlock);
+
+        _dictionary[id] = new PointInfo(position.X, position.Y, width, height, border, textBlock);
+    }
+
+    public void Move(int id, Point position, Size size, string? errorMessage)
+    {
+        var (width, height) = (size.Width, size.Height);
+        if (_dictionary.TryGetValue(id, out var info))
+        {
+#nullable enable
+            var viewWidth = width;
+            var viewHeight = height;
+
+            if (width <= 0.01)
+            {
+                width = info.Width;
+                viewWidth = width;
+            }
+
+            if (height <= 0.01)
+            {
+                height = info.Height;
+                viewHeight = height;
+            }
+
+            viewWidth = Math.Max(5, viewWidth);
+            viewHeight = Math.Max(5, viewHeight);
+
+            var borderRenderTransform = (TranslateTransform)info.Border.RenderTransform!;
+            borderRenderTransform.X = position.X - viewWidth / 2;
+            borderRenderTransform.Y = position.Y - viewHeight / 2;
+
+            var textBlock = info.TextBlock;
+            textBlock.Text =
+                $"Id:{id}\r\nX: {position.X}, Y: {position.Y}\r\nWidth: {width:F2}, Height: {height:F2}\r\n{errorMessage}";
+
+            var textBlockRenderTransform = (TranslateTransform)textBlock.RenderTransform!;
+            textBlockRenderTransform.X = position.X;
+            textBlockRenderTransform.Y = position.Y;
+
+            _dictionary[id] = info with
+            {
+                X = position.X,
+                Y = position.Y,
+
+                Width = width,
+                Height = height
+            };
+#nullable restore
+        }
+    }
+
+    public async void Up(int id)
+    {
+        if (_dictionary.TryGetValue(id, out var info))
+        {
+            RootGrid.Children.Remove(info.Border);
+
+            info.TextBlock.Text = "IsUp=true\r\n" + info.TextBlock.Text;
+            info.TextBlock.Opacity = 0.9;
+
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            info.TextBlock.Foreground = Brushes.Black;
+            info.TextBlock.Opacity = 0.5;
+            for (int i = 0; i < 5; i++)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                info.TextBlock.Opacity = (5 - i) * 0.1;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            RootGrid.Children.Remove(info.TextBlock);
+        }
+    }
+}
+
+struct PointInfo
+{
+    public PointInfo(double x, double y, double width, double height, Border border, TextBlock textBlock)
+    {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+        Border = border;
+        TextBlock = textBlock;
+    }
+
+    public double X { get; set; }
+    public double Y { get; set; }
+    public double Width { get; set; }
+    public double Height { get; set; }
+    public Border Border { get; }
+    public TextBlock TextBlock { get; }
+}


### PR DESCRIPTION
如果在触摸初始化之前，调用 WMI 将会导致触摸失效，原因是找不到 COM 注册接口。在 dotnet 6 版本里面的 PimcManager 对应的 COM 组件是放在相同的进程里面，预计是 WMI 注册导致 COM 挂了，具体原因还没去看