### PR TITLE
添加测试麒麟设备触摸面积错误工具

### DIFF
--- a/ManipulationDemoCpfX11/CPF/README.md
+++ b/ManipulationDemoCpfX11/CPF/README.md
@@ -1,1 +1,1 @@
-本文件夹代码从 https://gitee.com/csharpui/CPF 拷贝
+﻿本文件夹代码从 https://gitee.com/csharpui/CPF 和 https://github.com/AvaloniaUI/Avalonia 拷贝

--- a/ManipulationDemoCpfX11/CPF/XLib.cs
+++ b/ManipulationDemoCpfX11/CPF/XLib.cs
@@ -168,9 +168,17 @@ namespace CPF.Linux
 
         public static string? GetAtomName(IntPtr display, IntPtr atom)
         {
+            if (atom is 0)
+            {
+                return null;
+            }
+
             var ptr = XGetAtomName(display, atom);
             if (ptr == IntPtr.Zero)
+            {
                 return null;
+            }
+
             var s = Marshal.PtrToStringAnsi(ptr);
             XFree(ptr);
             return s;

--- a/ManipulationDemoCpfX11/Program.cs
+++ b/ManipulationDemoCpfX11/Program.cs
@@ -1,9 +1,6 @@
 ﻿using System.Diagnostics;
-
 using CPF.Linux;
-
 using ManipulationDemoCpfX11.Utils;
-
 using SkiaSharp;
 
 using static CPF.Linux.XLib;
@@ -60,7 +57,7 @@ if (OperatingSystem.IsLinux())
         var edidInfo = readEdidInfoResult.EdidInfo;
         Console.WriteLine($"读取 Edid 成功，屏幕宽高：{edidInfo.BasicDisplayParameters.MonitorPhysicalWidth.Value}cmx{edidInfo.BasicDisplayParameters.MonitorPhysicalHeight.Value}cm");
 
-        physicalWidth = (int) edidInfo.BasicDisplayParameters.MonitorPhysicalWidth.Value;
+        physicalWidth = (int)edidInfo.BasicDisplayParameters.MonitorPhysicalWidth.Value;
         physicalHeight = (int) edidInfo.BasicDisplayParameters.MonitorPhysicalHeight.Value;
     }
     else
@@ -104,7 +101,7 @@ skCanvas.Clear(SKColors.White.WithAlpha(0x6C));
 var touchMajorAtom = XInternAtom(display, "Abs MT Touch Major", false);
 var touchMinorAtom = XInternAtom(display, "Abs MT Touch Minor", false);
 var pressureAtom = XInternAtom(display, "Abs MT Pressure", false);
-var orientationAtom = XInternAtom(display, "Abs MT Orientation", false);
+var orientationAtom = XInternAtom(display, "Abs MT Orientation",false);
 
 Console.WriteLine($"ABS_MT_TOUCH_MAJOR={touchMajorAtom} Name={XLib.GetAtomName(display, touchMajorAtom)} ABS_MT_TOUCH_MINOR={touchMinorAtom} Name={XLib.GetAtomName(display, touchMinorAtom)} Abs_MT_Pressure={pressureAtom} Name={XLib.GetAtomName(display, pressureAtom)} Abs_MT_Orientation={orientationAtom} Name={XLib.GetAtomName(display, orientationAtom)}");
 
@@ -307,7 +304,7 @@ while (true)
 
                             if (orientationValuatorClassInfo.HasValue)
                             {
-                                if (valuatorDictionary.TryGetValue(orientationValuatorClassInfo.Value.Number, out var value))
+                                if (valuatorDictionary.TryGetValue(orientationValuatorClassInfo.Value.Number,out var value))
                                 {
                                     Log($"Abs MT Orientation Value={value} Min={orientationValuatorClassInfo.Value.Min} Max={orientationValuatorClassInfo.Value.Max} Resolution={orientationValuatorClassInfo.Value.Resolution}");
                                 }
@@ -378,9 +375,7 @@ void Draw()
 
             skCanvas.DrawRect((float) (value.X - pixelWidth / 2), (float) (value.Y - pixelHeight / 2), (float) pixelWidth, (float) pixelHeight, skPaint);
 
-            //logMessage += $" W={pixelWidth}px,{physicalWidthValue}cm H={pixelHeight}px,{physicalHeightValue}cm MajorValuator={touchMajorValuatorClassInfo.Value.Max} MinorValuator={touchMinorValuatorClassInfo?.Max} Resolution={touchMajorValuatorClassInfo.Value.Resolution}";
-
-            logMessage = $"Id={value.Id} Width: {pixelWidth:0.00}px {physicalWidthValue:0.00}cm(S) {value.TouchMajor / touchMajorValuatorClassInfo.Value.Resolution * 100d/*单位是0.1毫米，乘以100等于厘米*/:0.00}cm(R) Value={value.TouchMajor} MaxValuator={touchMajorValuatorClassInfo.Value.Max} Resolution={touchMajorValuatorClassInfo.Value.Resolution}";
+            logMessage += $" W={pixelWidth}px,{physicalWidthValue}cm H={pixelHeight}px,{physicalHeightValue}cm MajorValuator={touchMajorValuatorClassInfo.Value.Max} MinorValuator={touchMinorValuatorClassInfo?.Max}";
         }
 
         skPaint.IsLinearText = false;

--- a/ManipulationDemoCpfX11/Program.cs
+++ b/ManipulationDemoCpfX11/Program.cs
@@ -1,7 +1,10 @@
 ﻿using System.Diagnostics;
+
 using CPF.Linux;
+
 using ManipulationDemoCpfX11.TouchFramework;
 using ManipulationDemoCpfX11.Utils;
+
 using SkiaSharp;
 
 using static CPF.Linux.XLib;
@@ -58,7 +61,7 @@ if (OperatingSystem.IsLinux())
         var edidInfo = readEdidInfoResult.EdidInfo;
         Console.WriteLine($"读取 Edid 成功，屏幕宽高：{edidInfo.BasicDisplayParameters.MonitorPhysicalWidth.Value}cmx{edidInfo.BasicDisplayParameters.MonitorPhysicalHeight.Value}cm");
 
-        physicalWidth = (int)edidInfo.BasicDisplayParameters.MonitorPhysicalWidth.Value;
+        physicalWidth = (int) edidInfo.BasicDisplayParameters.MonitorPhysicalWidth.Value;
         physicalHeight = (int) edidInfo.BasicDisplayParameters.MonitorPhysicalHeight.Value;
     }
     else
@@ -66,13 +69,17 @@ if (OperatingSystem.IsLinux())
         Console.WriteLine($"读取 Edid 失败，错误原因：{readEdidInfoResult.ErrorMessage}");
     }
 }
-
+else
+{
+    Console.WriteLine("当前程序只能在 Linux 上运行");
+    return;
+}
 
 var handle = XCreateWindow(display, rootWindow, 0, 0, width, height, 5,
-    32,
-    (int) CreateWindowArgs.InputOutput,
-visual,
-(nuint) valueMask, ref xSetWindowAttributes);
+        32,
+        (int) CreateWindowArgs.InputOutput,
+    visual,
+    (nuint) valueMask, ref xSetWindowAttributes);
 XEventMask ignoredMask = XEventMask.SubstructureRedirectMask | XEventMask.ResizeRedirectMask |
                          XEventMask.PointerMotionHintMask;
 var mask = new IntPtr(0xffffff ^ (int) ignoredMask);
@@ -100,110 +107,8 @@ skPaint.Typeface = typeface;
 skPaint.Color = SKColors.Black;
 skCanvas.Clear(SKColors.White.WithAlpha(0x5C));
 
-var touchMajorAtom = XInternAtom(display, "Abs MT Touch Major", false);
-var touchMinorAtom = XInternAtom(display, "Abs MT Touch Minor", false);
-var pressureAtom = XInternAtom(display, "Abs MT Pressure", false);
-var orientationAtom = XInternAtom(display, "Abs MT Orientation",false);
-
-Console.WriteLine($"ABS_MT_TOUCH_MAJOR={touchMajorAtom} Name={XLib.GetAtomName(display, touchMajorAtom)} ABS_MT_TOUCH_MINOR={touchMinorAtom} Name={XLib.GetAtomName(display, touchMinorAtom)} Abs_MT_Pressure={pressureAtom} Name={XLib.GetAtomName(display, pressureAtom)} Abs_MT_Orientation={orientationAtom} Name={XLib.GetAtomName(display, orientationAtom)}");
-
-var valuators = new List<XIValuatorClassInfo>();
-var scrollers = new List<XIScrollClassInfo>();
-
-XIValuatorClassInfo? touchMajorValuatorClassInfo = null;
-XIValuatorClassInfo? touchMinorValuatorClassInfo = null;
-XIValuatorClassInfo? pressureValuatorClassInfo = null;
-XIValuatorClassInfo? orientationValuatorClassInfo = null;
-
-unsafe
-{
-    var devices = (XIDeviceInfo*) XIQueryDevice(display,
-        (int) XiPredefinedDeviceId.XIAllMasterDevices, out int num);
-
-    XIDeviceInfo? pointerDevice = default;
-    for (var c = 0; c < num; c++)
-    {
-        Console.WriteLine($"XIDeviceInfo [{c}] {devices[c].Deviceid} {devices[c].Use}");
-
-        if (devices[c].Use == XiDeviceType.XIMasterPointer)
-        {
-            pointerDevice ??= devices[c];
-            // 特意不用 break; 多次进入循环，用于输出更多调试信息
-            continue;
-        }
-    }
-
-    if (pointerDevice != null)
-    {
-        var multiTouchEventTypes = new List<XiEventType>
-        {
-            XiEventType.XI_TouchBegin,
-            XiEventType.XI_TouchUpdate,
-            XiEventType.XI_TouchEnd,
-
-            XiEventType.XI_Motion,
-            XiEventType.XI_ButtonPress,
-            XiEventType.XI_ButtonRelease,
-            XiEventType.XI_Leave,
-            XiEventType.XI_Enter,
-        };
-
-        XiSelectEvents(display, handle, new Dictionary<int, List<XiEventType>> { [pointerDevice.Value.Deviceid] = multiTouchEventTypes });
-
-        for (int i = 0; i < pointerDevice.Value.NumClasses; i++)
-        {
-            var xiAnyClassInfo = pointerDevice.Value.Classes[i];
-            if (xiAnyClassInfo->Type == XiDeviceClass.XIValuatorClass)
-            {
-                valuators.Add(*((XIValuatorClassInfo**) pointerDevice.Value.Classes)[i]);
-            }
-            else if (xiAnyClassInfo->Type == XiDeviceClass.XIScrollClass)
-            {
-                scrollers.Add(*((XIScrollClassInfo**) pointerDevice.Value.Classes)[i]);
-            }
-        }
-
-        foreach (var xiValuatorClassInfo in valuators)
-        {
-            if (xiValuatorClassInfo.Label == touchMajorAtom)
-            {
-                Console.WriteLine($"TouchMajorAtom Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution}");
-
-                touchMajorValuatorClassInfo = xiValuatorClassInfo;
-            }
-            else if (xiValuatorClassInfo.Label == touchMinorAtom)
-            {
-                Console.WriteLine($"TouchMinorAtom Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution}");
-
-                touchMinorValuatorClassInfo = xiValuatorClassInfo;
-            }
-            else if (xiValuatorClassInfo.Label == pressureAtom)
-            {
-                Console.WriteLine($"PressureAtom Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution}");
-
-                pressureValuatorClassInfo = xiValuatorClassInfo;
-            }
-            else if (xiValuatorClassInfo.Label == orientationAtom)
-            {
-                Console.WriteLine($"OrientationAtom Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution}");
-                orientationValuatorClassInfo = xiValuatorClassInfo;
-            }
-            else
-            {
-                Console.WriteLine($"XiValuatorClassInfo Label={xiValuatorClassInfo.Label}({XLib.GetAtomName(display, xiValuatorClassInfo.Label)} Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution})");
-            }
-        }
-
-        if (touchMajorValuatorClassInfo is null)
-        {
-            Console.WriteLine("Can't find TouchMajorAtom 丢失触摸宽度高度");
-        }
-    }
-    else
-    {
-        Console.WriteLine("pointerDevice==null");
-    }
-}
+var xiValuatorManager = new XIValuatorManager(display, handle);
+xiValuatorManager.UpdateValuator();
 
 var dictionary = new Dictionary<int, TouchInfo>();
 bool isSendExposeEvent = false;
@@ -274,9 +179,9 @@ while (true)
                                 }
                             }
 
-                            if (touchMajorValuatorClassInfo.HasValue)
+                            if (xiValuatorManager.TouchMajorValuatorClassInfo.HasValue)
                             {
-                                if (valuatorDictionary.TryGetValue(touchMajorValuatorClassInfo.Value.Number, out var value) && (!ignoreZeroWidthHeight || value != 0))
+                                if (valuatorDictionary.TryGetValue(xiValuatorManager.TouchMajorValuatorClassInfo.Value.Number, out var value) && (!ignoreZeroWidthHeight || value != 0))
                                 {
                                     touchInfo = touchInfo with
                                     {
@@ -289,9 +194,9 @@ while (true)
                                 }
                             }
 
-                            if (touchMinorValuatorClassInfo.HasValue)
+                            if (xiValuatorManager.TouchMinorValuatorClassInfo.HasValue)
                             {
-                                if (valuatorDictionary.TryGetValue(touchMinorValuatorClassInfo.Value.Number, out var value) && (!ignoreZeroWidthHeight || value != 0))
+                                if (valuatorDictionary.TryGetValue(xiValuatorManager.TouchMinorValuatorClassInfo.Value.Number, out var value) && (!ignoreZeroWidthHeight || value != 0))
                                 {
                                     touchInfo = touchInfo with
                                     {
@@ -344,33 +249,14 @@ void LogTouchInfo(TouchInfo value)
 {
     string logMessage = $"Id={value.Id};X={value.X} Y={value.Y};TouchMajor={value.TouchMajor} TouchMinor={value.TouchMinor}";
 
-    var touchMajorScale = value.TouchMajor / touchMajorValuatorClassInfo.Value.Max;
-    double pixelWidth = touchMajorScale * xDisplayWidth;
-    double pixelHeight;
-    double physicalWidthValue = double.NaN;
-    double physicalHeightValue = double.NaN;
+    var touchSize = value.GetTouchSize(xiValuatorManager, physicalWidth, physicalHeight);
 
-    if (physicalWidth > 0)
-    {
-        physicalWidthValue = touchMajorScale * physicalWidth;
-    }
+    double pixelWidth = touchSize.PixelWidth;
+    double pixelHeight = touchSize.PixelHeight;
+    double physicalWidthValue = touchSize.PhysicalCentimeterWidth;
+    double physicalHeightValue = touchSize.PhysicalCentimeterHeight;
 
-    if (touchMinorValuatorClassInfo is null)
-    {
-        pixelHeight = pixelWidth;
-    }
-    else
-    {
-        var touchMinorScale = value.TouchMinor / touchMinorValuatorClassInfo.Value.Max;
-        pixelHeight = touchMinorScale * xDisplayHeight;
-
-        if (physicalHeight > 0)
-        {
-            physicalHeightValue = touchMinorScale * physicalHeight;
-        }
-    }
-
-    logMessage += $" W={pixelWidth:0.00}px,{physicalWidthValue:0.00}cm H={pixelHeight:0.00}px,{physicalHeightValue:0.00}cm MajorValuatorMax={touchMajorValuatorClassInfo?.Max:0.00} MinorValuatorMax={touchMinorValuatorClassInfo?.Max:0.00}";
+    logMessage += $" W={pixelWidth:0.00}px,{physicalWidthValue:0.00}cm H={pixelHeight:0.00}px,{physicalHeightValue:0.00}cm MajorValuatorMax={xiValuatorManager.TouchMajorValuatorClassInfo?.Max:0.00} MinorValuatorMax={xiValuatorManager.TouchMinorValuatorClassInfo?.Max:0.00}";
 
     Log(logMessage);
 }
@@ -381,33 +267,12 @@ void Draw()
 
     foreach (var value in dictionary.Values)
     {
-        if (touchMajorValuatorClassInfo != null)
+        if (xiValuatorManager.TouchMajorValuatorClassInfo != null)
         {
-            var touchMajorScale = value.TouchMajor / touchMajorValuatorClassInfo.Value.Max;
-            double pixelWidth = touchMajorScale * xDisplayWidth;
-            double pixelHeight;
-            double physicalWidthValue = double.NaN;
-            double physicalHeightValue = double.NaN;
+            var touchSize = value.GetTouchSize(xiValuatorManager, physicalWidth, physicalHeight);
 
-            if (physicalWidth > 0)
-            {
-                physicalWidthValue = touchMajorScale * physicalWidth;
-            }
-
-            if (touchMinorValuatorClassInfo is null)
-            {
-                pixelHeight = pixelWidth;
-            }
-            else
-            {
-                var touchMinorScale = value.TouchMinor / touchMinorValuatorClassInfo.Value.Max;
-                pixelHeight = touchMinorScale * xDisplayHeight;
-
-                if (physicalHeight > 0)
-                {
-                    physicalHeightValue = touchMinorScale * physicalHeight;
-                }
-            }
+            double pixelWidth = touchSize.PixelWidth;
+            double pixelHeight = touchSize.PixelHeight;
 
             skCanvas.DrawRect((float) (value.X - pixelWidth / 2), (float) (value.Y - pixelHeight / 2), (float) pixelWidth, (float) pixelHeight, skPaint);
         }
@@ -418,7 +283,7 @@ void Draw()
                     """;
         if (value.TouchStatus == TouchStatus.Up)
         {
-            text = "[已抬起];" + text;
+            text = "[Up];" + text;
         }
 
         skPaint.Style = SKPaintStyle.Fill;
@@ -441,7 +306,6 @@ void Log(string message)
     var logFile = Path.Join(AppContext.BaseDirectory, $"Log_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.txt");
     File.AppendAllLines(logFile, [$"[{DateTime.Now:yyyy-MM-dd HH:mm:ss,fff}] {message}"]);
 }
-
 
 static XImage CreateImage(SKBitmap skBitmap)
 {

--- a/ManipulationDemoCpfX11/Program.cs
+++ b/ManipulationDemoCpfX11/Program.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-
-using CPF.Linux;
+﻿using CPF.Linux;
 
 using ManipulationDemoCpfX11.TouchFramework;
 using ManipulationDemoCpfX11.Utils;
@@ -126,6 +124,7 @@ while (true)
 
     if (@event.type == XEventName.Expose)
     {
+        Draw();
         XPutImage(display, handle, gc, ref xImage, @event.ExposeEvent.x, @event.ExposeEvent.y, @event.ExposeEvent.x, @event.ExposeEvent.y, (uint) @event.ExposeEvent.width,
             (uint) @event.ExposeEvent.height);
         isSendExposeEvent = false;
@@ -233,13 +232,13 @@ while (true)
                             };
                         }
                     }
-
-                    Draw();
+                    
+                    InvalidateVisual();
                 }
             }
             finally
             {
-
+                XFreeEventData(display, data);
             }
         }
     }
@@ -261,6 +260,17 @@ void LogTouchInfo(TouchInfo value)
     Log(logMessage);
 }
 
+void InvalidateVisual()
+{
+    if (isSendExposeEvent)
+    {
+        return;
+    }
+
+    SendExposeEvent(display, handle, 0, 0, width, height);
+    isSendExposeEvent = true;
+}
+
 void Draw()
 {
     skCanvas.Clear(SKColors.White.WithAlpha(0x2C));
@@ -279,7 +289,7 @@ void Draw()
 
         skPaint.IsLinearText = false;
         var text = $"""
-                    Id={value.Id};X={value.X} Y={value.Y};W={value.TouchMajor} H={value.TouchMinor}
+                    Id={value.Id};X={value.X:0.00} Y={value.Y:0.00};W={value.TouchMajor:0.00} H={value.TouchMinor:0.00}
                     """;
         if (value.TouchStatus == TouchStatus.Up)
         {
@@ -290,14 +300,6 @@ void Draw()
         skCanvas.DrawText(text, (float) value.X, (float) value.Y, skPaint);
         skPaint.Style = SKPaintStyle.Stroke;
     }
-
-    if (isSendExposeEvent)
-    {
-        return;
-    }
-
-    SendExposeEvent(display, handle, 0, 0, width, height);
-    isSendExposeEvent = true;
 }
 
 void Log(string message)

--- a/ManipulationDemoCpfX11/Program.cs
+++ b/ManipulationDemoCpfX11/Program.cs
@@ -1,6 +1,9 @@
 ﻿using System.Diagnostics;
+
 using CPF.Linux;
+
 using ManipulationDemoCpfX11.Utils;
+
 using SkiaSharp;
 
 using static CPF.Linux.XLib;
@@ -57,7 +60,7 @@ if (OperatingSystem.IsLinux())
         var edidInfo = readEdidInfoResult.EdidInfo;
         Console.WriteLine($"读取 Edid 成功，屏幕宽高：{edidInfo.BasicDisplayParameters.MonitorPhysicalWidth.Value}cmx{edidInfo.BasicDisplayParameters.MonitorPhysicalHeight.Value}cm");
 
-        physicalWidth = (int)edidInfo.BasicDisplayParameters.MonitorPhysicalWidth.Value;
+        physicalWidth = (int) edidInfo.BasicDisplayParameters.MonitorPhysicalWidth.Value;
         physicalHeight = (int) edidInfo.BasicDisplayParameters.MonitorPhysicalHeight.Value;
     }
     else
@@ -101,7 +104,7 @@ skCanvas.Clear(SKColors.White.WithAlpha(0x6C));
 var touchMajorAtom = XInternAtom(display, "Abs MT Touch Major", false);
 var touchMinorAtom = XInternAtom(display, "Abs MT Touch Minor", false);
 var pressureAtom = XInternAtom(display, "Abs MT Pressure", false);
-var orientationAtom = XInternAtom(display, "Abs MT Orientation",false);
+var orientationAtom = XInternAtom(display, "Abs MT Orientation", false);
 
 Console.WriteLine($"ABS_MT_TOUCH_MAJOR={touchMajorAtom} Name={XLib.GetAtomName(display, touchMajorAtom)} ABS_MT_TOUCH_MINOR={touchMinorAtom} Name={XLib.GetAtomName(display, touchMinorAtom)} Abs_MT_Pressure={pressureAtom} Name={XLib.GetAtomName(display, pressureAtom)} Abs_MT_Orientation={orientationAtom} Name={XLib.GetAtomName(display, orientationAtom)}");
 
@@ -304,7 +307,7 @@ while (true)
 
                             if (orientationValuatorClassInfo.HasValue)
                             {
-                                if (valuatorDictionary.TryGetValue(orientationValuatorClassInfo.Value.Number,out var value))
+                                if (valuatorDictionary.TryGetValue(orientationValuatorClassInfo.Value.Number, out var value))
                                 {
                                     Log($"Abs MT Orientation Value={value} Min={orientationValuatorClassInfo.Value.Min} Max={orientationValuatorClassInfo.Value.Max} Resolution={orientationValuatorClassInfo.Value.Resolution}");
                                 }
@@ -375,7 +378,9 @@ void Draw()
 
             skCanvas.DrawRect((float) (value.X - pixelWidth / 2), (float) (value.Y - pixelHeight / 2), (float) pixelWidth, (float) pixelHeight, skPaint);
 
-            logMessage += $" W={pixelWidth}px,{physicalWidthValue}cm H={pixelHeight}px,{physicalHeightValue}cm MajorValuator={touchMajorValuatorClassInfo.Value.Max} MinorValuator={touchMinorValuatorClassInfo?.Max}";
+            //logMessage += $" W={pixelWidth}px,{physicalWidthValue}cm H={pixelHeight}px,{physicalHeightValue}cm MajorValuator={touchMajorValuatorClassInfo.Value.Max} MinorValuator={touchMinorValuatorClassInfo?.Max} Resolution={touchMajorValuatorClassInfo.Value.Resolution}";
+
+            logMessage = $"Id={value.Id} Width: {pixelWidth:0.00}px {physicalWidthValue:0.00}cm(S) {value.TouchMajor / touchMajorValuatorClassInfo.Value.Resolution * 100d/*单位是0.1毫米，乘以100等于厘米*/:0.00}cm(R) Value={value.TouchMajor} MaxValuator={touchMajorValuatorClassInfo.Value.Max} Resolution={touchMajorValuatorClassInfo.Value.Resolution}";
         }
 
         skPaint.IsLinearText = false;

--- a/ManipulationDemoCpfX11/Program.cs
+++ b/ManipulationDemoCpfX11/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using CPF.Linux;
+using ManipulationDemoCpfX11.TouchFramework;
 using ManipulationDemoCpfX11.Utils;
 using SkiaSharp;
 
@@ -420,7 +421,9 @@ void Draw()
             text = "[已抬起];" + text;
         }
 
+        skPaint.Style = SKPaintStyle.Fill;
         skCanvas.DrawText(text, (float) value.X, (float) value.Y, skPaint);
+        skPaint.Style = SKPaintStyle.Stroke;
     }
 
     if (isSendExposeEvent)
@@ -489,13 +492,3 @@ static void SendExposeEvent(IntPtr display, IntPtr window, int x, int y, int wid
     XFlush(display);
 }
 
-record TouchInfo(int Id, double X, double Y, double TouchMajor, double TouchMinor, TouchStatus TouchStatus)
-{
-}
-
-enum TouchStatus
-{
-    Down,
-    Move,
-    Up,
-}

--- a/ManipulationDemoCpfX11/Program.cs
+++ b/ManipulationDemoCpfX11/Program.cs
@@ -370,7 +370,7 @@ void LogTouchInfo(TouchInfo value)
         }
     }
 
-    logMessage += $" W={pixelWidth}px,{physicalWidthValue}cm H={pixelHeight}px,{physicalHeightValue}cm MajorValuatorMax={touchMajorValuatorClassInfo.Value.Max} MinorValuatorMax={touchMinorValuatorClassInfo?.Max}";
+    logMessage += $" W={pixelWidth:0.00}px,{physicalWidthValue:0.00}cm H={pixelHeight:0.00}px,{physicalHeightValue:0.00}cm MajorValuatorMax={touchMajorValuatorClassInfo?.Max:0.00} MinorValuatorMax={touchMinorValuatorClassInfo?.Max:0.00}";
 
     Log(logMessage);
 }

--- a/ManipulationDemoCpfX11/Program.cs
+++ b/ManipulationDemoCpfX11/Program.cs
@@ -106,7 +106,7 @@ skPaint.Color = SKColors.Black;
 skCanvas.Clear(SKColors.White.WithAlpha(0x5C));
 
 var xiValuatorManager = new XIValuatorManager(display, handle);
-xiValuatorManager.UpdateValuator();
+xiValuatorManager.Init();
 
 var dictionary = new Dictionary<int, TouchInfo>();
 bool isSendExposeEvent = false;
@@ -242,7 +242,9 @@ while (true)
                 }
                 else if (xiEvent->evtype is XiEventType.XI_DeviceChanged)
                 {
-                    xiValuatorManager.UpdateValuator();
+                    var changed = (XIDeviceChangedEvent*) xiEvent;
+
+                    xiValuatorManager.UpdateValuators(changed->Classes, changed->NumClasses);
                 }
             }
             finally

--- a/ManipulationDemoCpfX11/Program.cs
+++ b/ManipulationDemoCpfX11/Program.cs
@@ -232,8 +232,17 @@ while (true)
                             };
                         }
                     }
-                    
+                    else if (xiEvent->evtype is XiEventType.XI_Motion)
+                    {
+                        dictionary[xiDeviceEvent->detail] = new TouchInfo(xiDeviceEvent->detail, x, y, -1, -1, TouchStatus.Move);
+                        LogTouchInfo(dictionary[xiDeviceEvent->detail]);
+                    }
+
                     InvalidateVisual();
+                }
+                else if (xiEvent->evtype is XiEventType.XI_DeviceChanged)
+                {
+                    xiValuatorManager.UpdateValuator();
                 }
             }
             finally

--- a/ManipulationDemoCpfX11/TouchFramework/TouchInfo.cs
+++ b/ManipulationDemoCpfX11/TouchFramework/TouchInfo.cs
@@ -12,8 +12,6 @@ public record TouchInfo(int Id, double X, double Y, double TouchMajor, double To
 {
     public TouchSize GetTouchSize(XIValuatorManager valuatorManager, int edidPhysicalWidth, int edidPhysicalHeight)
     {
-        var value = this;
-
         var display = valuatorManager.Display;
         var screen = XDefaultScreen(display);
         var xDisplayWidth = XDisplayWidth(display, screen);
@@ -24,9 +22,14 @@ public record TouchInfo(int Id, double X, double Y, double TouchMajor, double To
         double physicalWidthValue = double.NaN;
         double physicalHeightValue = double.NaN;
 
+        if (TouchMajor < 0 && TouchMinor < 0)
+        {
+            return new TouchSize(-1, -1, -1, -1);
+        }
+
         if (valuatorManager.TouchMajorValuatorClassInfo is not null)
         {
-            var touchMajorScale = value.TouchMajor / valuatorManager.TouchMajorValuatorClassInfo.Value.Max;
+            var touchMajorScale = TouchMajor / valuatorManager.TouchMajorValuatorClassInfo.Value.Max;
             pixelWidth = touchMajorScale * xDisplayWidth;
 
             if (edidPhysicalWidth > 0)
@@ -41,7 +44,7 @@ public record TouchInfo(int Id, double X, double Y, double TouchMajor, double To
         }
         else
         {
-            var touchMinorScale = value.TouchMinor / valuatorManager.TouchMinorValuatorClassInfo.Value.Max;
+            var touchMinorScale = TouchMinor / valuatorManager.TouchMinorValuatorClassInfo.Value.Max;
             pixelHeight = touchMinorScale * xDisplayHeight;
 
             if (edidPhysicalHeight > 0)

--- a/ManipulationDemoCpfX11/TouchFramework/TouchInfo.cs
+++ b/ManipulationDemoCpfX11/TouchFramework/TouchInfo.cs
@@ -4,9 +4,61 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using static CPF.Linux.XLib;
+
 namespace ManipulationDemoCpfX11.TouchFramework;
 
 public record TouchInfo(int Id, double X, double Y, double TouchMajor, double TouchMinor, TouchStatus TouchStatus)
+{
+    public TouchSize GetTouchSize(XIValuatorManager valuatorManager, int edidPhysicalWidth, int edidPhysicalHeight)
+    {
+        var value = this;
+
+        var display = valuatorManager.Display;
+        var screen = XDefaultScreen(display);
+        var xDisplayWidth = XDisplayWidth(display, screen);
+        var xDisplayHeight = XDisplayHeight(display, screen);
+
+        double pixelWidth = 0;
+        double pixelHeight = 0;
+        double physicalWidthValue = double.NaN;
+        double physicalHeightValue = double.NaN;
+
+        if (valuatorManager.TouchMajorValuatorClassInfo is not null)
+        {
+            var touchMajorScale = value.TouchMajor / valuatorManager.TouchMajorValuatorClassInfo.Value.Max;
+            pixelWidth = touchMajorScale * xDisplayWidth;
+
+            if (edidPhysicalWidth > 0)
+            {
+                physicalWidthValue = touchMajorScale * edidPhysicalWidth;
+            }
+        }
+
+        if (valuatorManager.TouchMinorValuatorClassInfo is null)
+        {
+            pixelHeight = pixelWidth;
+        }
+        else
+        {
+            var touchMinorScale = value.TouchMinor / valuatorManager.TouchMinorValuatorClassInfo.Value.Max;
+            pixelHeight = touchMinorScale * xDisplayHeight;
+
+            if (edidPhysicalHeight > 0)
+            {
+                physicalHeightValue = touchMinorScale * edidPhysicalHeight;
+            }
+        }
+
+        return new TouchSize(pixelWidth, pixelHeight, physicalWidthValue, physicalHeightValue);
+    }
+}
+
+public readonly record struct TouchSize(
+    double PixelWidth,
+    double PixelHeight,
+    double PhysicalCentimeterWidth,
+    double PhysicalCentimeterHeight)
 {
 }
 

--- a/ManipulationDemoCpfX11/TouchFramework/TouchInfo.cs
+++ b/ManipulationDemoCpfX11/TouchFramework/TouchInfo.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ManipulationDemoCpfX11.TouchFramework;
+
+public record TouchInfo(int Id, double X, double Y, double TouchMajor, double TouchMinor, TouchStatus TouchStatus)
+{
+}
+
+public enum TouchStatus
+{
+    Down,
+    Move,
+    Up,
+}

--- a/ManipulationDemoCpfX11/TouchFramework/XIValuatorManager.cs
+++ b/ManipulationDemoCpfX11/TouchFramework/XIValuatorManager.cs
@@ -26,6 +26,11 @@ public unsafe class XIValuatorManager
     {
         Console.WriteLine($"Start UpdateValuator ============");
 
+        TouchMajorValuatorClassInfo = null;
+        TouchMinorValuatorClassInfo = null;
+        PressureValuatorClassInfo = null;
+        OrientationValuatorClassInfo = null;
+
         var touchMajorAtom = XLib.XInternAtom(Display, "Abs MT Touch Major", false);
         var touchMinorAtom = XLib.XInternAtom(Display, "Abs MT Touch Minor", false);
         var pressureAtom = XLib.XInternAtom(Display, "Abs MT Pressure", false);

--- a/ManipulationDemoCpfX11/TouchFramework/XIValuatorManager.cs
+++ b/ManipulationDemoCpfX11/TouchFramework/XIValuatorManager.cs
@@ -1,0 +1,134 @@
+﻿using CPF.Linux;
+
+namespace ManipulationDemoCpfX11.TouchFramework;
+
+public unsafe class XIValuatorManager
+{
+    public XIValuatorManager(nint display, nint x11WindowXId)
+    {
+        Display = display;
+        _x11WindowXId = x11WindowXId;
+    }
+
+    internal XIValuatorClassInfo? TouchMajorValuatorClassInfo { get; private set; } = null;
+
+    internal XIValuatorClassInfo? TouchMinorValuatorClassInfo { get; private set; } = null;
+
+    internal XIValuatorClassInfo? PressureValuatorClassInfo { get; private set; } = null;
+
+    internal XIValuatorClassInfo? OrientationValuatorClassInfo { get; private set; } = null;
+
+    private readonly nint _x11WindowXId;
+
+    public IntPtr Display { get; }
+
+    public void UpdateValuator()
+    {
+        Console.WriteLine($"Start UpdateValuator ============");
+
+        var touchMajorAtom = XLib.XInternAtom(Display, "Abs MT Touch Major", false);
+        var touchMinorAtom = XLib.XInternAtom(Display, "Abs MT Touch Minor", false);
+        var pressureAtom = XLib.XInternAtom(Display, "Abs MT Pressure", false);
+        var orientationAtom = XLib.XInternAtom(Display, "Abs MT Orientation", false);
+
+        Console.WriteLine($"ABS_MT_TOUCH_MAJOR={touchMajorAtom} Name={XLib.GetAtomName(Display, touchMajorAtom)} ABS_MT_TOUCH_MINOR={touchMinorAtom} Name={XLib.GetAtomName(Display, touchMinorAtom)} Abs_MT_Pressure={pressureAtom} Name={XLib.GetAtomName(Display, pressureAtom)} Abs_MT_Orientation={orientationAtom} Name={XLib.GetAtomName(Display, orientationAtom)}");
+
+        var devices = (XIDeviceInfo*) XLib.XIQueryDevice(Display,
+            (int) XiPredefinedDeviceId.XIAllMasterDevices, out int num);
+
+        XIDeviceInfo? pointerDevice = default;
+        for (var c = 0; c < num; c++)
+        {
+            Console.WriteLine($"XIDeviceInfo [{c}] {devices[c].Deviceid} {devices[c].Use}");
+
+            if (devices[c].Use == XiDeviceType.XIMasterPointer)
+            {
+                pointerDevice ??= devices[c];
+                // 特意不用 break; 多次进入循环，用于输出更多调试信息
+                continue;
+            }
+        }
+
+        if (pointerDevice != null)
+        {
+            var valuators = new List<XIValuatorClassInfo>();
+            var scrollers = new List<XIScrollClassInfo>();
+
+            var multiTouchEventTypes = new List<XiEventType>
+            {
+                XiEventType.XI_TouchBegin,
+                XiEventType.XI_TouchUpdate,
+                XiEventType.XI_TouchEnd,
+
+                XiEventType.XI_Motion,
+                XiEventType.XI_ButtonPress,
+                XiEventType.XI_ButtonRelease,
+                XiEventType.XI_Leave,
+                XiEventType.XI_Enter,
+            };
+
+            XLib.XiSelectEvents(Display, _x11WindowXId,
+                new Dictionary<int, List<XiEventType>> { [pointerDevice.Value.Deviceid] = multiTouchEventTypes });
+
+            for (int i = 0; i < pointerDevice.Value.NumClasses; i++)
+            {
+                var xiAnyClassInfo = pointerDevice.Value.Classes[i];
+                if (xiAnyClassInfo->Type == XiDeviceClass.XIValuatorClass)
+                {
+                    valuators.Add(*((XIValuatorClassInfo**) pointerDevice.Value.Classes)[i]);
+                }
+                else if (xiAnyClassInfo->Type == XiDeviceClass.XIScrollClass)
+                {
+                    scrollers.Add(*((XIScrollClassInfo**) pointerDevice.Value.Classes)[i]);
+                }
+            }
+
+            foreach (var xiValuatorClassInfo in valuators)
+            {
+                if (xiValuatorClassInfo.Label == touchMajorAtom)
+                {
+                    Console.WriteLine(
+                        $"TouchMajorAtom Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution}");
+
+                    TouchMajorValuatorClassInfo = xiValuatorClassInfo;
+                }
+                else if (xiValuatorClassInfo.Label == touchMinorAtom)
+                {
+                    Console.WriteLine(
+                        $"TouchMinorAtom Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution}");
+
+                    TouchMinorValuatorClassInfo = xiValuatorClassInfo;
+                }
+                else if (xiValuatorClassInfo.Label == pressureAtom)
+                {
+                    Console.WriteLine(
+                        $"PressureAtom Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution}");
+
+                    PressureValuatorClassInfo = xiValuatorClassInfo;
+                }
+                else if (xiValuatorClassInfo.Label == orientationAtom)
+                {
+                    Console.WriteLine(
+                        $"OrientationAtom Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution}");
+                    OrientationValuatorClassInfo = xiValuatorClassInfo;
+                }
+                else
+                {
+                    Console.WriteLine(
+                        $"XiValuatorClassInfo Label={xiValuatorClassInfo.Label}({XLib.GetAtomName(Display, xiValuatorClassInfo.Label)} Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution})");
+                }
+            }
+
+            if (TouchMajorValuatorClassInfo is null)
+            {
+                Console.WriteLine("Can't find TouchMajorAtom 丢失触摸宽度高度");
+            }
+        }
+        else
+        {
+            Console.WriteLine("pointerDevice==null");
+        }
+
+        Console.WriteLine($"End UpdateValuator ============");
+    }
+}

--- a/ManipulationDemoCpfX11/TouchFramework/XIValuatorManager.cs
+++ b/ManipulationDemoCpfX11/TouchFramework/XIValuatorManager.cs
@@ -70,6 +70,8 @@ public unsafe class XIValuatorManager
                 XiEventType.XI_ButtonRelease,
                 XiEventType.XI_Leave,
                 XiEventType.XI_Enter,
+
+                XiEventType.XI_DeviceChanged,
             };
 
             XLib.XiSelectEvents(Display, _x11WindowXId,

--- a/ManipulationDemoCpfX11/TouchFramework/XIValuatorManager.cs
+++ b/ManipulationDemoCpfX11/TouchFramework/XIValuatorManager.cs
@@ -114,8 +114,7 @@ public unsafe class XIValuatorManager
                 }
                 else
                 {
-                    Console.WriteLine(
-                        $"XiValuatorClassInfo Label={xiValuatorClassInfo.Label}({XLib.GetAtomName(Display, xiValuatorClassInfo.Label)} Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution})");
+                    Console.WriteLine($"XiValuatorClassInfo Label={xiValuatorClassInfo.Label}({XLib.GetAtomName(Display, xiValuatorClassInfo.Label)} Value={xiValuatorClassInfo.Value}; Max={xiValuatorClassInfo.Max:0.00}; Min={xiValuatorClassInfo.Min:0.00}; Resolution={xiValuatorClassInfo.Resolution})");
                 }
             }
 


### PR DESCRIPTION
逻辑太复杂了，将其拆分一下。麒麟设备的触摸设备和鼠标设备切换的时候，报告的触摸信息是不正确的。之前的工具没有实现切换触摸设备和鼠标设备的刷新，没有处理设备变更消息，当前更改加上此功能